### PR TITLE
Add WASM support as feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ categories = ["gui", "game-development"]
 [features]
 default = ["log"]
 log = ["tracing-log", "tracing-subscriber/tracing-log"]
+wasmbind = ["chrono/wasmbind"]
 
 [dependencies]
 chrono = { version = "0.4.24", default-features = false, features = ["clock"] }


### PR DESCRIPTION
Chrono's `now` function only works if the `wasmbind` feature is
enabled (It's one of the defaults, but egui_tracing explicitly
disables defaults)

This change allow consumers of egui_tracing to re-enable wasm support
using the `wasmbind` feature flag.
