### PR TITLE
[TEST] chore: release v0.2.5

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Add wasm target
         run: rustup target add wasm32-unknown-unknown
       - name: Install cargo-binstall
-        run: curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+        uses: cargo-bins/cargo-binstall@v1.10.5
       - run: cargo binstall --no-confirm just wasm-pack
       - run: just build
         working-directory: ./examples/eframe-wasm32

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -20,6 +20,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
       - name: Run release-plz
+        id: release-plz
         uses: MarcoIeni/release-plz-action@v0.5
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
@@ -27,15 +28,16 @@ jobs:
       - name: Update all version references
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OUTPUTS: ${{ steps.release-plz.outputs }}
           RELEASES: ${{ steps.release-plz.outputs.releases }}
         run: |
           set -e
-
-          echo "$RELEASES"
+          echo "outputs: $OUTPUTS"
+          echo "releases: $RELEASES"
           release_version=$(echo "$RELEASES" | jq -r '.[0].version')
           sed -i "s/egui_tracing = \"[^\"]*\"/egui_tracing = \"${release_version}\"/g" README.md
           sed -i "s/version = \"[^\"]*\"/version = \"${release_version}\"/g" examples/eframe/Cargo.toml
           sed -i "s/version = \"[^\"]*\"/version = \"${release_version}\"/g" examples/eframe-wasm32/Cargo.toml
           git add .
-          git commit -m "chore: update all version references"
+          git commit -m "chore: update all version references to ${release_version}"
           git push

--- a/egui-tracing/CHANGELOG.md
+++ b/egui-tracing/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.5](https://github.com/grievouz/egui_tracing/compare/egui_tracing-v0.2.4...egui_tracing-v0.2.5) - 2024-09-17
+
+### Added
+
+- enhance hover text with more comprehensive content ([#22](https://github.com/grievouz/egui_tracing/pull/22))
+
+### Fixed
+
+- remove color override and use workspace dependencies ([#21](https://github.com/grievouz/egui_tracing/pull/21))
+
 ## [0.2.4](https://github.com/grievouz/egui_tracing/compare/egui_tracing-v0.2.3...egui_tracing-v0.2.4) - 2024-09-15
 
 ### Other

--- a/egui-tracing/Cargo.toml
+++ b/egui-tracing/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "egui_tracing"
 description = "Integrates tracing and logging with egui for event collection/visualization"
-version = "0.2.4"
+version = "0.2.5"
 edition = "2021"
 license = "Unlicense"
 repository = "https://github.com/grievouz/egui_tracing"


### PR DESCRIPTION
## 🤖 New release
* `egui_tracing`: 0.2.4 -> 0.2.5 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.5](https://github.com/grievouz/egui_tracing/compare/egui_tracing-v0.2.4...egui_tracing-v0.2.5) - 2024-09-17

### Added

- enhance hover text with more comprehensive content ([#22](https://github.com/grievouz/egui_tracing/pull/22))

### Fixed

- remove color override and use workspace dependencies ([#21](https://github.com/grievouz/egui_tracing/pull/21))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).