### PR TITLE
chore: release v0.2.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Add `egui_tracing` to your `Cargo.toml` dependencies:
 
 ```toml
 [dependencies]
-egui_tracing = "0.2.4"
+egui_tracing = "0.2.5"
 ```
 
 ## Example

--- a/egui-tracing/CHANGELOG.md
+++ b/egui-tracing/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.5](https://github.com/grievouz/egui_tracing/compare/egui_tracing-v0.2.4...egui_tracing-v0.2.5) - 2024-09-17
+
+### Added
+
+- enhance hover text with more comprehensive content ([#22](https://github.com/grievouz/egui_tracing/pull/22))
+
+### Fixed
+
+- remove color override and use workspace dependencies ([#21](https://github.com/grievouz/egui_tracing/pull/21))
+
 ## [0.2.4](https://github.com/grievouz/egui_tracing/compare/egui_tracing-v0.2.3...egui_tracing-v0.2.4) - 2024-09-15
 
 ### Other

--- a/egui-tracing/Cargo.toml
+++ b/egui-tracing/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "egui_tracing"
 description = "Integrates tracing and logging with egui for event collection/visualization"
-version = "0.2.4"
+version = "0.2.5"
 edition = "2021"
 license = "Unlicense"
 repository = "https://github.com/grievouz/egui_tracing"

--- a/examples/eframe-wasm32/Cargo.toml
+++ b/examples/eframe-wasm32/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "example-eframe-wasm32"
-version = "0.2.4"
+version = "0.2.5"
 edition = "2021"
 publish = false
 

--- a/examples/eframe/Cargo.toml
+++ b/examples/eframe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "example-eframe"
-version = "0.2.4"
+version = "0.2.5"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
## 🤖 New release
* `egui_tracing`: 0.2.4 -> 0.2.5 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.5](https://github.com/grievouz/egui_tracing/compare/egui_tracing-v0.2.4...egui_tracing-v0.2.5) - 2024-09-17

### Added

- enhance hover text with more comprehensive content ([#22](https://github.com/grievouz/egui_tracing/pull/22))

### Fixed

- remove color override and use workspace dependencies ([#21](https://github.com/grievouz/egui_tracing/pull/21))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).