### PR TITLE
chore: release v0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Add `egui_tracing` to your `Cargo.toml` dependencies:
 
 ```toml
 [dependencies]
-egui_tracing = "0.2.6"
+egui_tracing = "0.3.0"
 ```
 
 ## Usage

--- a/egui-tracing/CHANGELOG.md
+++ b/egui-tracing/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/grievouz/egui_tracing/compare/egui_tracing-v0.2.6...egui_tracing-v0.3.0) - 2026-04-10
+
+### Added
+
+- improve labels and UI component initialization
+- add internationalization support for labels
+- improve logging UI and collector configuration
+- add expandable log rows to show full event details
+- allow target menu to close on click outside
+
+### Other
+
+- update preview image
+- update dependency versioning ([#40](https://github.com/grievouz/egui_tracing/pull/40))
+- disable resizing and use default frame for detail panel
+- improve logging performance and UI responsiveness
+- optimize event collection and filtering with caching
+- Replace custom table with egui_extras
+- update egui and eframe to 0.34
+
 ## [0.2.6](https://github.com/grievouz/egui_tracing/compare/egui_tracing-v0.2.5...egui_tracing-v0.2.6) - 2024-09-27
 
 ### Added

--- a/egui-tracing/Cargo.toml
+++ b/egui-tracing/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "egui_tracing"
 description = "Integrates tracing and logging with egui for event collection/visualization"
-version = "0.2.6"
+version = "0.3.0"
 edition = "2021"
 license = "Unlicense"
 repository = "https://github.com/grievouz/egui_tracing"

--- a/examples/eframe-wasm32/Cargo.toml
+++ b/examples/eframe-wasm32/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "example-eframe-wasm32"
-version = "0.2.6"
+version = "0.3.0"
 edition = "2021"
 publish = false
 

--- a/examples/eframe/Cargo.toml
+++ b/examples/eframe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "example-eframe"
-version = "0.2.6"
+version = "0.3.0"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION



## 🤖 New release

* `egui_tracing`: 0.2.6 -> 0.3.0 (⚠ API breaking changes)

### ⚠ `egui_tracing` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field CollectedEvent.message in /tmp/.tmp0d0Q1M/egui_tracing/egui-tracing/src/tracing/event.rs:11
  field CollectedEvent.collapsed_summary in /tmp/.tmp0d0Q1M/egui_tracing/egui-tracing/src/tracing/event.rs:14
  field CollectedEvent.message in /tmp/.tmp0d0Q1M/egui_tracing/egui-tracing/src/tracing/event.rs:11
  field CollectedEvent.collapsed_summary in /tmp/.tmp0d0Q1M/egui_tracing/egui-tracing/src/tracing/event.rs:14

--- failure feature_missing: package feature removed or renamed ---

Description:
A feature has been removed from this package's Cargo.toml. This will break downstream crates which enable that feature.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#cargo-feature-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/feature_missing.ron

Failed in:
  feature reexport in the package's Cargo.toml

--- failure inherent_method_const_removed: pub method is no longer const ---

Description:
A publicly-visible method or associated fn is no longer `const` and can no longer be used in a `const` context.
        ref: https://doc.rust-lang.org/reference/const_eval.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/inherent_method_const_removed.ron

Failed in:
  Logs::new in /tmp/.tmp0d0Q1M/egui_tracing/egui-tracing/src/ui/mod.rs:27
  Logs::new in /tmp/.tmp0d0Q1M/egui_tracing/egui-tracing/src/ui/mod.rs:27

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/inherent_method_missing.ron

Failed in:
  EventCollector::with_level, previously in file /tmp/.tmpiqFiTi/egui_tracing/src/tracing/collector.rs:30
  EventCollector::with_level, previously in file /tmp/.tmpiqFiTi/egui_tracing/src/tracing/collector.rs:30
  EventCollector::with_level, previously in file /tmp/.tmpiqFiTi/egui_tracing/src/tracing/collector.rs:30
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.0](https://github.com/grievouz/egui_tracing/compare/egui_tracing-v0.2.6...egui_tracing-v0.3.0) - 2026-04-10

### Added

- improve labels and UI component initialization
- add internationalization support for labels
- improve logging UI and collector configuration
- add expandable log rows to show full event details
- allow target menu to close on click outside

### Other

- update preview image
- update dependency versioning ([#40](https://github.com/grievouz/egui_tracing/pull/40))
- disable resizing and use default frame for detail panel
- improve logging performance and UI responsiveness
- optimize event collection and filtering with caching
- Replace custom table with egui_extras
- update egui and eframe to 0.34
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).