### PR TITLE
Simplify use for wasm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,17 @@ resolver = "2"
 members = ["egui-tracing", "examples/eframe", "examples/eframe-wasm32"]
 
 [workspace.dependencies]
+chrono = { version = "0.4", default-features = false }
 eframe = { version = "0.34", default-features = false }
 egui = { version = "0.34", default-features = false }
 egui_extras = { version = "0.34", default-features = false }
+egui_tracing = { path = "egui-tracing" }
+globset = "0.4"
+imbl = "7"
 tracing = { version = "0.1", default-features = false }
+tracing-log = { version = "0.2", default-features = false }
+tracing-subscriber = { version = "0.3", default-features = false }
+unicode-segmentation = "1"
+wasm-bindgen = "0.2.93"
+wasm-bindgen-futures = "0.4.42"
+web-sys = "0.3.70"

--- a/egui-tracing/Cargo.toml
+++ b/egui-tracing/Cargo.toml
@@ -15,12 +15,12 @@ log = ["tracing-log", "tracing-subscriber/tracing-log"]
 wasmbind = ["chrono/wasmbind"]
 
 [dependencies]
-chrono = { version = "0.4", default-features = false, features = ["clock"] }
+chrono = { workspace = true, features = ["clock"] }
 egui = { workspace = true }
 egui_extras = { workspace = true }
-imbl = "7"
-globset = "0.4"
+globset = { workspace = true }
+imbl = { workspace = true }
 tracing = { workspace = true, default-features = false }
-tracing-log = { version = "0.2", optional = true, default-features = false }
-tracing-subscriber = { version = "0.3", default-features = false, features = ["registry"] }
-unicode-segmentation = "1"
+tracing-log = { workspace = true, optional = true }
+tracing-subscriber = { workspace = true, features = ["registry"] }
+unicode-segmentation = { workspace = true }

--- a/egui-tracing/Cargo.toml
+++ b/egui-tracing/Cargo.toml
@@ -12,6 +12,7 @@ categories = ["gui", "game-development"]
 default = ["log", "egui-default"]
 egui-default = ["egui/default"]
 log = ["tracing-log", "tracing-subscriber/tracing-log"]
+## Used to be needed use on WASM but no longer needed. Detected by target now
 wasmbind = ["chrono/wasmbind"]
 
 [dependencies]
@@ -24,3 +25,7 @@ tracing = { workspace = true, default-features = false }
 tracing-log = { workspace = true, optional = true }
 tracing-subscriber = { workspace = true, features = ["registry"] }
 unicode-segmentation = { workspace = true }
+
+# web:
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+chrono = { workspace = true, features = ["wasmbind"] }

--- a/examples/eframe-wasm32/Cargo.toml
+++ b/examples/eframe-wasm32/Cargo.toml
@@ -9,17 +9,12 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 eframe = { workspace = true, features = ["glow"] }
-egui_tracing = { path = "../../egui-tracing", features = [
-    "wasmbind",
-] }
+egui_tracing = { workspace = true, features = ["wasmbind"] }
+getrandom = { version = "*", features = ["js"] }
 tracing = { workspace = true, default-features = false }
-wasm-bindgen = "0.2.93"
-wasm-bindgen-futures = "0.4.42"
-web-sys = "0.3.70"
-
-[dependencies.getrandom]
-version = "*"
-features = ["js"]
+wasm-bindgen = { workspace = true }
+wasm-bindgen-futures = { workspace = true }
+web-sys = { workspace = true }
 
 [features]
 default = ["eframe/default"]

--- a/examples/eframe-wasm32/Cargo.toml
+++ b/examples/eframe-wasm32/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 eframe = { workspace = true, features = ["glow"] }
-egui_tracing = { workspace = true, features = ["wasmbind"] }
+egui_tracing = { workspace = true }
 getrandom = { version = "*", features = ["js"] }
 tracing = { workspace = true, default-features = false }
 wasm-bindgen = { workspace = true }

--- a/examples/eframe/Cargo.toml
+++ b/examples/eframe/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 publish = false
 
 [dependencies]
-egui_tracing = { path = "../../egui-tracing" }
 eframe = { workspace = true }
+egui_tracing = { workspace = true }
 tracing = { workspace = true, default-features = false }
 
 [features]


### PR DESCRIPTION
I got stuck for a bit trying to figure out how to get the wasm version to work until I noticed the feature flag. I did this PR so the next person won't need to look for the flag. I didn't remove the flag as that would be a breaking change but it's no longer needed.

PS. If you don't like moving the dependency version up to the workspace level just let me know and I'll revert that part of the PR.